### PR TITLE
Remove search for eui test

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/panels.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/panels.spec.js
@@ -254,7 +254,6 @@ describe('Testing a panel', () => {
   });
 
   it('Add ppl filter to panel', () => {
-    cy.get('.euiTextArea').invoke('attr', 'placeholder').should('contain', 'where');
     cy.get('[data-test-subj="searchAutocompleteTextArea"]')
       .click()
       .wait(1500)


### PR DESCRIPTION
### Description

The plugin repo has this removed and I verified this in this in the CI and this helps it pass.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

### Issues Resolved

n/a

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
